### PR TITLE
Implement livereactload for hot loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This will boot up a server at http://localhost:3000
  - [x] Client side rendering
  - [x] Isomorphic routing with execution of actions based on route match
  - [x] Server side hot loading (no browser refresh tho)
- - [ ] Client side hot loading (need help: https://github.com/lukemorton/republic/pull/12)
+ - [x] Client side hot loading of views extending React.Component
  - [ ] `republic new` command for new projects
  - [ ] Rewrite republic with tests (initial dev was spike)
  - [ ] Promo video

--- a/examples/app/views/hello/test.jsx
+++ b/examples/app/views/hello/test.jsx
@@ -1,8 +1,10 @@
-export default function Test() {
-  return (
-    <div>
-      test
-      <Link to="/">Hello</Link>
-    </div>
-  );
+export default class Test extends React.Component {
+  render() {
+    return (
+      <div>
+        test
+        <Link to="/">Hello</Link>
+      </div>
+    );
+  }
 }

--- a/examples/app/views/hello/world.jsx
+++ b/examples/app/views/hello/world.jsx
@@ -1,8 +1,10 @@
-export default function World(props) {
-  return (
-    <div>
-      Hello World: {props.world}
-      <Link to="/test">Test</Link>
-    </div>
-  );
+export default class World extends React.Component {
+  render() {
+    return (
+      <div>
+        Hello World: {this.props.world}
+        <Link to="/test">Test</Link>
+      </div>
+    );
+  }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",
+    "babel-plugin-react-transform": "^2.0.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babelify": "^7.2.0",
@@ -47,7 +48,9 @@
     "eslint-config-standard-react": "^1.2.1",
     "eslint-plugin-react": "^3.15.0",
     "eslint-plugin-standard": "^1.3.1",
+    "livereactload": "^2.1.1",
     "morgan": "^1.6.1",
+    "react-proxy": "^1.1.2",
     "watchify": "^3.7.0"
   },
   "eslintConfig": {
@@ -76,6 +79,18 @@
     "presets": [
       "es2015",
       "react"
-    ]
+    ],
+    "env": {
+      "development": {
+        "plugins": [
+          ["react-transform", {
+            "transforms": [{
+              "transform": "livereactload/babel-transform",
+              "imports": ["react"]
+            }]
+          }]
+        ]
+      }
+    }
   }
 }

--- a/src/application.js
+++ b/src/application.js
@@ -1,5 +1,6 @@
 import browserify from 'browserify';
 import watchify from 'watchify';
+import livereactload from 'livereactload';
 import fs from 'fs';
 import path from 'path';
 
@@ -103,7 +104,7 @@ export function watchClient({ config, onBuildFinish }) {
   const entries = buildClientEntryPoint(config);
   const cache = {};
   const packageCache = {};
-  const plugin = [watchify];
+  const plugin = [watchify, livereactload];
 
   ensureTmpPathExists(config);
 

--- a/src/application.js
+++ b/src/application.js
@@ -101,12 +101,12 @@ export function buildClient({ config, onBuildFinish }) {
 }
 
 export function watchClient({ config, onBuildFinish }) {
+  ensureTmpPathExists(config);
+
   const entries = buildClientEntryPoint(config);
   const cache = {};
   const packageCache = {};
   const plugin = [watchify, livereactload];
-
-  ensureTmpPathExists(config);
 
   let b = browserify({ cache,
                        entries,

--- a/src/application.js
+++ b/src/application.js
@@ -26,7 +26,8 @@ function buildIndexEntryPoint(config) {
   const entryPointPath = config.app.tmpPath + '/index.js';
   const requireGlobs = "['app/actions/*.jsx', 'app/views/**/*.jsx', 'config/*.jsx']";
   console.log('Writing index entry point to', entryPointPath);
-  fs.writeFileSync(entryPointPath, `export default require('bulk-require')('${config.app.rootPath}', ${requireGlobs});`);
+  fs.writeFileSync(entryPointPath, `module.onReload && module.onReload(() => true);
+export default require('bulk-require')('${config.app.rootPath}', ${requireGlobs});`);
   console.log('Finished writing index entry point.');
   return entryPointPath;
 }

--- a/src/configuration.js
+++ b/src/configuration.js
@@ -2,10 +2,10 @@ import path from 'path';
 
 function defaultConfig() {
   const app = {
-    assetsPath: path.join(process.cwd(), '/app/assets/'),
-    tmpPath: path.join(process.cwd(), '/tmp/'),
-    rootPath: path.join(process.cwd(), '/'),
-    viewsPath: path.join(process.cwd(), '/app/views/')
+    assetsPath: path.resolve(process.cwd() + '/app/assets/'),
+    tmpPath: path.resolve(process.cwd() + '/tmp/'),
+    rootPath: path.resolve(process.cwd() + '/'),
+    viewsPath: path.resolve(process.cwd() + '/app/views/')
   };
 
   const express = {


### PR DESCRIPTION
The aim of this pull request is to implement client side hot reloading. I'm running into a few issues and would love some help.
## Recreate the problem

Follow these steps to recreate the problem.
1. Clone this repo
2. `git checkout feature/hot-loading`
3. `cd examples`
4. `npm install && sudo npm link && republic dev`
5. Open http://localhost:3000 in browser
6. Change text in `examples/app/views/hello/world.jsx`
## The error

When attempting the above I get the following error:

![Image showing stack trace](https://dl.dropboxusercontent.com/s/ygj6avjdjua3qjg/Screenshot%202016-02-14%2009.57.40.png?dl=0)
## Expected outcome

Only the `world.jsx` file should be reloaded. I did not expect the parent files to be reloaded and as such redux and react router. How can I ensure only userland files (i.e. ones in their app directory not republic) are hot loaded?
## Related links
- https://github.com/reactjs/redux/pull/667
- https://github.com/reactjs/react-router/issues/2182#issuecomment-147016657
- https://github.com/milankinen/livereactload/issues/43
